### PR TITLE
Shared directory support

### DIFF
--- a/Microverse.xcodeproj/project.pbxproj
+++ b/Microverse.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		3526598E26BFEFBF001D5029 /* VirtualMachineController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3526598D26BFEFBF001D5029 /* VirtualMachineController.swift */; };
 		3526599026BFF2E2001D5029 /* MicroverseErrors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3526598F26BFF2E2001D5029 /* MicroverseErrors.swift */; };
+		3526599226C001D4001D5029 /* SharedDirectoriesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3526599126C001D4001D5029 /* SharedDirectoriesView.swift */; };
+		3526599426C00210001D5029 /* SharedDirectory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3526599326C00210001D5029 /* SharedDirectory.swift */; };
 		352AF07626BAFDD700AFD751 /* PathField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 352AF07526BAFDD700AFD751 /* PathField.swift */; };
 		352AF07A26BB026900AFD751 /* MacRestoreImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 352AF07926BB026900AFD751 /* MacRestoreImageView.swift */; };
 		359B9B0626B8AAC100AA3989 /* MicroverseDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = 359B9B0526B8AAC100AA3989 /* MicroverseDocument.swift */; };
@@ -40,6 +42,8 @@
 /* Begin PBXFileReference section */
 		3526598D26BFEFBF001D5029 /* VirtualMachineController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VirtualMachineController.swift; sourceTree = "<group>"; };
 		3526598F26BFF2E2001D5029 /* MicroverseErrors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MicroverseErrors.swift; sourceTree = "<group>"; };
+		3526599126C001D4001D5029 /* SharedDirectoriesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedDirectoriesView.swift; sourceTree = "<group>"; };
+		3526599326C00210001D5029 /* SharedDirectory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedDirectory.swift; sourceTree = "<group>"; };
 		352AF07526BAFDD700AFD751 /* PathField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PathField.swift; sourceTree = "<group>"; };
 		352AF07926BB026900AFD751 /* MacRestoreImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacRestoreImageView.swift; sourceTree = "<group>"; };
 		359B9B0526B8AAC100AA3989 /* MicroverseDocument.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MicroverseDocument.swift; sourceTree = "<group>"; };
@@ -97,6 +101,7 @@
 				35FE87DF26BECD2E009B9B51 /* MacOSInstallView.swift */,
 				352AF07926BB026900AFD751 /* MacRestoreImageView.swift */,
 				352AF07526BAFDD700AFD751 /* PathField.swift */,
+				3526599126C001D4001D5029 /* SharedDirectoriesView.swift */,
 				35CF8D7B26B8431300E83536 /* VirtualMachineConfigurationView.swift */,
 				35CF8D7926B8421B00E83536 /* VirtualMachineView.swift */,
 			);
@@ -132,6 +137,7 @@
 				35FE87D926BEC041009B9B51 /* LinuxVirtualMachine.swift */,
 				35FE87DB26BEC049009B9B51 /* MacOSVirtualMachine.swift */,
 				3526598F26BFF2E2001D5029 /* MicroverseErrors.swift */,
+				3526599326C00210001D5029 /* SharedDirectory.swift */,
 				35CF8D7526B836A900E83536 /* VirtualMachine.swift */,
 				35CF8D7D26B855E200E83536 /* VirtualMachineConfiguration.swift */,
 				3526598D26BFEFBF001D5029 /* VirtualMachineController.swift */,
@@ -255,11 +261,13 @@
 				359B9B0626B8AAC100AA3989 /* MicroverseDocument.swift in Sources */,
 				35CF8D6126B8300F00E83536 /* MicroverseApp.swift in Sources */,
 				35CF8D8226B87D8600E83536 /* LinuxBootView.swift in Sources */,
+				3526599226C001D4001D5029 /* SharedDirectoriesView.swift in Sources */,
 				35CF8D8E26B89E9B00E83536 /* NSWindowExtensions.swift in Sources */,
 				35FE87D426BEB7C1009B9B51 /* BlankDocumentView.swift in Sources */,
 				35FE87D826BEBD62009B9B51 /* MacOSDocumentView.swift in Sources */,
 				35FE87DE26BEC05C009B9B51 /* ConfigurableVirtualMachine.swift in Sources */,
 				35FE87E226BEE980009B9B51 /* MacAuxiliaryStorageView.swift in Sources */,
+				3526599426C00210001D5029 /* SharedDirectory.swift in Sources */,
 				35CF8D7A26B8421B00E83536 /* VirtualMachineView.swift in Sources */,
 				35FE87E026BECD2E009B9B51 /* MacOSInstallView.swift in Sources */,
 				35CF8D8026B8704200E83536 /* DiskCreationView.swift in Sources */,

--- a/Microverse/Model/SharedDirectory.swift
+++ b/Microverse/Model/SharedDirectory.swift
@@ -1,0 +1,13 @@
+//
+//  SharedDirectory.swift
+//  SharedDirectory
+//
+//  Created by Justin Spahr-Summers on 08/08/2021.
+//
+
+import Foundation
+
+struct SharedDirectory: Codable, Equatable, Hashable {
+    var path: String = ""
+    var isReadOnly: Bool = false
+}

--- a/Microverse/Model/SharedDirectory.swift
+++ b/Microverse/Model/SharedDirectory.swift
@@ -9,5 +9,6 @@ import Foundation
 
 struct SharedDirectory: Codable, Equatable, Hashable {
     var path: String = ""
+    var tag: String = ""
     var isReadOnly: Bool = false
 }

--- a/Microverse/View/MacOSDocumentView.swift
+++ b/Microverse/View/MacOSDocumentView.swift
@@ -50,6 +50,7 @@ struct MacOSDocumentView: View {
                     }
                     
                     AttachedDisksView(diskImages: $virtualMachine.attachedDiskImages)
+                    SharedDirectoriesView(sharedDirectories: $virtualMachine.sharedDirectories)
                     
                     if virtualMachine.startupDiskURL != nil {
                         VirtualMachineConfigurationView(configuration: $virtualMachine.configuration)

--- a/Microverse/View/SharedDirectoriesView.swift
+++ b/Microverse/View/SharedDirectoriesView.swift
@@ -12,7 +12,8 @@ struct SharedDirectoryView: View {
     @Binding var sharedDirectory: SharedDirectory
     
     var body: some View {
-        PathField(title: "", path: $sharedDirectory.path, allowedContentTypes: [UTType.directory])
+        PathField(title: "Directory:", path: $sharedDirectory.path, allowedContentTypes: [UTType.directory])
+        TextField("Tag:", text: $sharedDirectory.tag)
         Toggle("Read only", isOn: $sharedDirectory.isReadOnly)
     }
 }
@@ -25,12 +26,12 @@ struct SharedDirectoriesView: View {
             HStack {
                 Form {
                     ForEach(Array($sharedDirectories.enumerated()), id: \.offset) { index, element in
+                        SharedDirectoryView(sharedDirectory: $sharedDirectories[index])
                         HStack {
+                            Spacer()
                             Button("Remove") {
                                 sharedDirectories.remove(at: index)
                             }
-                            Spacer()
-                            SharedDirectoryView(sharedDirectory: $sharedDirectories[index])
                         }
                     }
                     HStack {
@@ -47,7 +48,7 @@ struct SharedDirectoriesView: View {
 
 struct SharedDirectoriesView_Previews: PreviewProvider {
     struct Holder: View {
-        @State var sharedDirectories: [SharedDirectory] = []
+        @State var sharedDirectories: [SharedDirectory] = [SharedDirectory()]
         var body: some View {
             SharedDirectoriesView(sharedDirectories: $sharedDirectories)
         }

--- a/Microverse/View/SharedDirectoriesView.swift
+++ b/Microverse/View/SharedDirectoriesView.swift
@@ -1,0 +1,59 @@
+//
+//  SharedDirectoriesView.swift
+//  SharedDirectoriesView
+//
+//  Created by Justin Spahr-Summers on 08/08/2021.
+//
+
+import SwiftUI
+import UniformTypeIdentifiers
+
+struct SharedDirectoryView: View {
+    @Binding var sharedDirectory: SharedDirectory
+    
+    var body: some View {
+        PathField(title: "", path: $sharedDirectory.path, allowedContentTypes: [UTType.directory])
+        Toggle("Read only", isOn: $sharedDirectory.isReadOnly)
+    }
+}
+
+struct SharedDirectoriesView: View {
+    @Binding var sharedDirectories: [SharedDirectory]
+    
+    var body: some View {
+        GroupBox("Shared Directories") {
+            HStack {
+                Form {
+                    ForEach(Array($sharedDirectories.enumerated()), id: \.offset) { index, element in
+                        HStack {
+                            Button("Remove") {
+                                sharedDirectories.remove(at: index)
+                            }
+                            Spacer()
+                            SharedDirectoryView(sharedDirectory: $sharedDirectories[index])
+                        }
+                    }
+                    HStack {
+                        Spacer()
+                        Button("Add") {
+                            sharedDirectories.append(SharedDirectory())
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+struct SharedDirectoriesView_Previews: PreviewProvider {
+    struct Holder: View {
+        @State var sharedDirectories: [SharedDirectory] = []
+        var body: some View {
+            SharedDirectoriesView(sharedDirectories: $sharedDirectories)
+        }
+    }
+    
+    static var previews: some View {
+        Holder()
+    }
+}


### PR DESCRIPTION
In theory, this adds support for sharing filesystems into a macOS guest. Unfortunately, I can't get `mount_9p` to work within the VM no matter what I do—so, parking this here for now.

Resolves #13.